### PR TITLE
Add rich text editor with import/export

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
+    <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
   "dependencies": {
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-icons": "^5.5.0"
+    "react-icons": "^5.5.0",
+    "react-quill": "^2.0.0",
+    "html-docx-js": "^0.4.0",
+    "mammoth": "^1.6.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",
@@ -23,6 +26,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
-    "vite": "^7.0.4"
+    "vite": "^7.0.4",
+    "typescript": "^5.4.0"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,11 @@
 import './App.css'
+import Editor from './Editor'
 
-function App() {
+const App: React.FC = () => {
   return (
     <div className="app-container">
       <h1>Reports</h1>
+      <Editor />
     </div>
   )
 }

--- a/src/Editor.tsx
+++ b/src/Editor.tsx
@@ -1,0 +1,56 @@
+import React, { useRef, useState } from 'react'
+import ReactQuill from 'react-quill'
+import 'react-quill/dist/quill.snow.css'
+import htmlDocx from 'html-docx-js/dist/html-docx'
+import * as mammoth from 'mammoth/mammoth.browser'
+import "./editor.css"
+
+const Editor: React.FC = () => {
+  const [value, setValue] = useState('')
+  const fileInputRef = useRef<HTMLInputElement | null>(null)
+
+  const handleImport = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    if (file.name.endsWith('.txt')) {
+      const text = await file.text()
+      setValue(text)
+    } else if (file.name.endsWith('.docx')) {
+      const result = await mammoth.convertToHtml({ arrayBuffer: await file.arrayBuffer() })
+      setValue(result.value)
+    }
+  }
+
+  const triggerImport = () => {
+    fileInputRef.current?.click()
+  }
+
+  const handleExport = () => {
+    const html = `<html><head></head><body>${value}</body></html>`
+    const blob = htmlDocx.asBlob(html)
+    const link = document.createElement('a')
+    link.href = URL.createObjectURL(blob)
+    link.download = 'document.docx'
+    link.click()
+    URL.revokeObjectURL(link.href)
+  }
+
+  return (
+    <div className="editor-container">
+      <div className="toolbar">
+        <button onClick={triggerImport}>Import</button>
+        <button onClick={handleExport}>Export</button>
+        <input
+          type="file"
+          accept=".txt,.docx"
+          style={{ display: 'none' }}
+          ref={fileInputRef}
+          onChange={handleImport}
+        />
+      </div>
+      <ReactQuill theme="snow" value={value} onChange={setValue} />
+    </div>
+  )
+}
+
+export default Editor

--- a/src/editor.css
+++ b/src/editor.css
@@ -1,0 +1,6 @@
+.toolbar {
+  margin-bottom: 1rem;
+}
+.editor-container {
+  margin-top: 1rem;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,9 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
-import App from './App.jsx'
+import App from './App'
 
-createRoot(document.getElementById('root')).render(
+createRoot(document.getElementById('root') as HTMLElement).render(
   <StrictMode>
     <App />
   </StrictMode>,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "strict": true,
+    "moduleResolution": "Bundler",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- convert project to TypeScript
- add docx/text import/export rich text editor
- hook editor into the main UI

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6877c42b2af88322b02e031c60868e90