### PR TITLE
Add import JSON, insert image, and RTL toggle

### DIFF
--- a/src/Editor.tsx
+++ b/src/Editor.tsx
@@ -8,6 +8,9 @@ import "./editor.css"
 const Editor: React.FC = () => {
   const [value, setValue] = useState('')
   const fileInputRef = useRef<HTMLInputElement | null>(null)
+  const jsonInputRef = useRef<HTMLInputElement | null>(null)
+  const imageInputRef = useRef<HTMLInputElement | null>(null)
+  const quillRef = useRef<ReactQuill | null>(null)
 
   const handleImport = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
@@ -21,8 +24,37 @@ const Editor: React.FC = () => {
     }
   }
 
+  const handleImportJson = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    const text = await file.text()
+    setValue(text)
+  }
+
+  const handleInsertImage = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    const reader = new FileReader()
+    reader.onload = () => {
+      const quill = quillRef.current?.getEditor()
+      const range = quill?.getSelection(true)
+      if (quill && range) {
+        quill.insertEmbed(range.index, 'image', reader.result as string)
+      }
+    }
+    reader.readAsDataURL(file)
+  }
+
   const triggerImport = () => {
     fileInputRef.current?.click()
+  }
+
+  const triggerImportJson = () => {
+    jsonInputRef.current?.click()
+  }
+
+  const triggerInsertImage = () => {
+    imageInputRef.current?.click()
   }
 
   const handleExport = () => {
@@ -35,11 +67,27 @@ const Editor: React.FC = () => {
     URL.revokeObjectURL(link.href)
   }
 
+  const toggleRTL = () => {
+    const quill = quillRef.current?.getEditor()
+    if (!quill) return
+    const root = quill.root
+    if (root.getAttribute('dir') === 'rtl') {
+      root.removeAttribute('dir')
+      root.style.textAlign = ''
+    } else {
+      root.setAttribute('dir', 'rtl')
+      root.style.textAlign = 'right'
+    }
+  }
+
   return (
     <div className="editor-container">
       <div className="toolbar">
         <button onClick={triggerImport}>Import</button>
+        <button onClick={triggerImportJson}>Import JSON</button>
         <button onClick={handleExport}>Export</button>
+        <button onClick={triggerInsertImage}>Insert Image</button>
+        <button onClick={toggleRTL}>RTL</button>
         <input
           type="file"
           accept=".txt,.docx"
@@ -47,8 +95,22 @@ const Editor: React.FC = () => {
           ref={fileInputRef}
           onChange={handleImport}
         />
+        <input
+          type="file"
+          accept=".json"
+          style={{ display: 'none' }}
+          ref={jsonInputRef}
+          onChange={handleImportJson}
+        />
+        <input
+          type="file"
+          accept="image/*"
+          style={{ display: 'none' }}
+          ref={imageInputRef}
+          onChange={handleInsertImage}
+        />
       </div>
-      <ReactQuill theme="snow" value={value} onChange={setValue} />
+      <ReactQuill theme="snow" value={value} onChange={setValue} ref={quillRef} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- support importing JSON as plain text
- add image insertion and JSON import buttons in editor toolbar
- provide RTL toggle for the paragraph direction

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' because dependencies are missing)*

------
https://chatgpt.com/codex/tasks/task_b_6877c8417d648322a8c2c70b155449b3