### PR TITLE
Apply RTL direction on DOCX import

### DIFF
--- a/src/Editor.tsx
+++ b/src/Editor.tsx
@@ -21,6 +21,12 @@ const Editor: React.FC = () => {
     } else if (file.name.endsWith('.docx')) {
       const result = await mammoth.convertToHtml({ arrayBuffer: await file.arrayBuffer() })
       setValue(result.value)
+      const quill = quillRef.current?.getEditor()
+      if (quill) {
+        const root = quill.root
+        root.setAttribute('dir', 'rtl')
+        root.style.textAlign = 'right'
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- set `dir="rtl"` and right alignment after converting DOCX to HTML

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' due to missing deps)*
- `npm ci` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_b_6877d4bd6410832285e2745d6c9724c0